### PR TITLE
Added mask option to pint.simulation.make_toas_uniform

### DIFF
--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -186,6 +186,7 @@ def make_fake_toas_uniform(
     name="fake",
     include_bipm=False,
     include_gps=True,
+    mask: np.ndarray = None
 ):
     """Make evenly spaced toas
 
@@ -239,8 +240,10 @@ def make_fake_toas_uniform(
     --------
     :func:`make_fake_toas`
     """
-
-    times = np.linspace(startMJD, endMJD, ntoas, dtype=np.longdouble) * u.d
+    if mask is not None:
+        times = np.linspace(startMJD, endMJD, ntoas, dtype=np.longdouble)[mask] * u.d
+    else:
+        times = np.linspace(startMJD, endMJD, ntoas, dtype=np.longdouble) * u.d
     if fuzz > 0:
         # apply some fuzz to the dates
         fuzz = np.random.normal(scale=fuzz.to_value(u.d), size=len(times)) * u.d


### PR DESCRIPTION
There is a for loop on line 254 of simulation.py meaning a long list of toas can add minutes to this function. If the intention is to only take a subset of these toas once calculated, a mask can select for these before the loop, substantially improving runtime. The default is to not apply a mask meaning no current code will be effected.